### PR TITLE
#166185759 Present deactivated users in gym overview

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "env/bin/python3.7"
-}

--- a/wger/core/static/js/wger-core.js
+++ b/wger/core/static/js/wger-core.js
@@ -698,3 +698,26 @@ $(document).ready(function () {
     window.location.href = targetUrl;
   });
 });
+
+function renderActiveUsers() {
+  var partial_active = document.getElementById("active");
+  var partial_inactive = document.getElementById("inactive");
+  var btn_active = document.getElementById("btn-active");
+  var btn_inactive = document.getElementById("btn-inactive");
+  partial_inactive.style.display = 'none';
+  btn_active.style.display = 'none'
+  btn_inactive.style.display = 'block'
+  partial_active.style.display = 'block';
+}
+
+function renderInactiveUsers() {
+  var partial_active = document.getElementById("active"); 
+  var partial_inactive = document.getElementById("inactive"); 
+  var btn_inactive = document.getElementById("btn-inactive");
+  var btn_active = document.getElementById("btn-active");
+  partial_inactive.style.display = 'block';
+  partial_active.style.display = 'none';
+  btn_active.style.display = 'block';
+  btn_inactive.style.display = 'none';
+}
+

--- a/wger/core/templates/user/list.html
+++ b/wger/core/templates/user/list.html
@@ -5,10 +5,22 @@
 
 
 {% block content %}
+    <p>
+        <button id="btn-active" style="display:none" onclick="renderActiveUsers()">View Active Users</button>
+        <button id="btn-inactive" onclick="renderInactiveUsers()">View Deactivated Users</button>
+    </p>
+    <div id="active">
     {% include 'gym/partial_user_list.html' %}
+    </div>
+    <div id="inactive" style="display: None">
+    {% include 'gym/partial_inactive_user_list.html' %}
+    </div>
+
+    <script src="{% static 'js/wger-core.js' %}" ></script>
 {% endblock %}
 
 
 {% block sidebar %}
-
+    
 {% endblock %}
+

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -578,14 +578,13 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
         """
         Return a list with the users, not really a queryset.
         """
-        out = {"admins": [], "members": []}
+        out = {'admins': [],
+               'members': []}
 
         for u in User.objects.select_related(
-            "usercache", "userprofile__gym"
-        ).all():
-            out["members"].append(
-                {"obj": u, "last_log": u.usercache.last_activity}
-            )
+                'usercache', 'userprofile__gym').all():
+            out['members'].append({'obj': u,
+                                  'last_log': u.usercache.last_activity})
 
         return out
 
@@ -594,15 +593,14 @@ class UserListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
         Pass other info to the template
         """
         context = super(UserListView, self).get_context_data(**kwargs)
-        context["show_gym"] = True
-        context["user_table"] = {
-            "keys": [
-                _("ID"),
-                _("Username"),
-                _("Name"),
-                _("Last activity"),
-                _("Gym"),
-            ],
-            "users": context["object_list"]["members"],
+        context['show_gym'] = True
+        context['user_table'] = {
+            'keys': [
+                _('ID'),
+                _('Username'),
+                _('Name'),
+                _('Last activity'),
+                _('Gym')],
+            'users': context['object_list']['members']
         }
         return context

--- a/wger/gym/templates/gym/partial_inactive_user_list.html
+++ b/wger/gym/templates/gym/partial_inactive_user_list.html
@@ -1,12 +1,12 @@
 {% load i18n staticfiles %}
-<h1>Active Users</h1>
+<h1>De-activated Users</h1>
 <link rel="stylesheet" type="text/css" href="{% static 'bower_components/datatables/media/css/dataTables.bootstrap.min.css' %}">
 <script src="{% static 'bower_components/datatables/media/js/jquery.dataTables.min.js' %}" ></script>
 <script src="{% static 'bower_components/datatables/media/js/dataTables.bootstrap.min.js' %}" ></script>
 <script>
 $(document).ready( function () {
     /* Make table sortable */
-    $('#main_member_list_active').DataTable({
+    $('#main_member_list_inactive').DataTable({
         paging: false,
         bFilter: true,
         bInfo : false
@@ -14,7 +14,7 @@ $(document).ready( function () {
 });
 </script>
 
-<table class="table table-hover" id="main_member_list_active">
+<table class="table table-hover" id="main_member_list_inactive">
 <thead>
 <tr>
     {% for key in user_table.keys %}
@@ -24,7 +24,7 @@ $(document).ready( function () {
 </thead>
 <tbody>
 {% for current_user in user_table.users %}
-    {% if current_user.obj.is_active %}
+    {% if not current_user.obj.is_active %}
         <tr>
             <td>
                 {{current_user.obj.pk}}


### PR DESCRIPTION
#### What does this PR do?

Display active and inactive users separately in the gym overview

#### Description of Task to be completed?

- filter and store active and inactive users in separate lists
- create a template for displaying the inactive users
- add two buttons for navigating between the active and inactive user
 views from the in the gym overview

#### How should this be manually tested?

- Clone this repo and set up the application locally according to the [README](https://github.com/andela/wger-space/blob/ft-display-active-inactive-users-166185759/README.rst) file.
- `cd` into `wger-space`, start the development server and navigate to the web app on `http://127.0.0.1:8000/`
- Create some users in the application that will be deactivated later. Also create a **superuser** using the command `python manage.py createsuperuser` and follow the prompts. 
- Log in to the app as the superuser  and navigate to `http://127.0.0.1:8000/en/user/list`
- Deactivate one of the users using this route `http://127.0.0.1:8000/en/user/{ID}/deactivate`. Replace ID with the id of one of your users. You should have a deactivated user after running that.
- Click on the `Deactivated Users` button to view the inactive users. The default view shows only active users. 

#### Any background context you want to provide?

- There is an issue in displaying the `navigation menu` on the development application. To navigate to the page for this feature, you will need to manually enter the URL above in your browser's address bar.

#### What are the relevant pivotal tracker stories?

[#166185759](https://www.pivotaltracker.com/story/show/166185759)

#### Screenshots (if appropriate)
- Active Users View
<img width="919" alt="Screen Shot 2019-05-31 at 16 42 43" src="https://user-images.githubusercontent.com/6644707/58709672-55a13380-83c3-11e9-967e-ac4a56d3b3ac.png">

- De-activated Users view
<img width="913" alt="Screen Shot 2019-05-31 at 16 43 03" src="https://user-images.githubusercontent.com/6644707/58709707-6651a980-83c3-11e9-9654-44f6decac3d1.png">



