### PR TITLE
#166185770 Move away from proprietary software Transifex 

### DIFF
--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -143,9 +143,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://www.transifex.com/rge/wger-workout-manager/">
+                                    <a href="https://translate.zanata.org/project/view/wger-space/">
                                         <span class="fa fa-external-link" aria-hidden="true"></span>
-                                        {% trans "Translate with Transifex" %}
+                                        {% trans "Translate with Zanata" %}
                                     </a>
                                 </li>
                             </ul>

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -126,7 +126,7 @@
                         {% endfor %}
                         <li class="divider"></li>
                         <li>
-                            <a href="https://www.transifex.com/rge/wger-workout-manager/">
+                            <a href="https://translate.zanata.org/project/view/wger-space/">
                                 <span class="{% fa_class 'plus' %}"></span>
                                 {% trans "Translate" %}
                             </a>

--- a/wger/core/templates/template_features.html
+++ b/wger/core/templates/template_features.html
@@ -96,7 +96,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://www.transifex.com/rge/wger-workout-manager/" title="{% trans 'Translate' %}">
+                        <a href="https://translate.zanata.org/project/view/wger-space/" title="{% trans 'Translate' %}">
                             <span class="{% fa_class 'globe' %}"></span>
                         </a>
                     </li>

--- a/wger/software/templates/contribute.html
+++ b/wger/software/templates/contribute.html
@@ -75,11 +75,11 @@ is too short or some other detail is missing or could be improved, tell!{% endbl
         <p>{% blocktrans %}Do you want to use wger in your own language?
 Do you think the current translation could be improved?
 The translations are easily managed and edited online, if you are interested,
-go to the transifex site, request access and we will set everything
+go to the zanata site, request access and we will set everything
 up. {% endblocktrans %}</p>
 
         <a class="btn btn-default"
-           href="https://www.transifex.com/rge/wger-workout-manager/">{% trans "Translate with Transifex" %} »</a>
+            href="https://translate.zanata.org/project/view/wger-space/">{% trans "Translate with Zanata" %} »</a>
     </div>
 </div>
 


### PR DESCRIPTION
#### What does this PR do?

- Move away from closed source software Transifex to open source Zanata, for translation of Wger into different languages.

#### Description of Task to be completed?

- create an account and project on [Zanata](https://translate.zanata.org)
- replace the project links to Transifex with [links](https://translate.zanata.org/iteration/view/wger-space/v1?dswid=8206) to the project on Zanata
- add the project files(HTML templates) to Zanata and select the languages into which the project will be translated.
- Translate some of the content of the HTML templates as proof of concept.

#### How should this be manually tested?

- Click on the link to the review app on Heroku to get a deployed instance of this PR.
- Click on the `login` button.
- On the `login` page, click the dropdown in the top right corner of the page that is labeled `English` (the button has a flag of Great Britain).
- In the subsequent dropdown menu, click the `Translate` link which will redirect you to the translation project on Zanata.
- Under the `versions` tab, click on the `v1` link to view the status' of the current translations as well as the percentage of each translation completed in each language.

#### What are the relevant pivotal tracker stories?

[#166185770](https://www.pivotaltracker.com/story/show/166185770)

#### Screenshots (if appropriate)

<img width="1435" alt="Screen Shot 2019-06-06 at 12 36 10" src="https://user-images.githubusercontent.com/6644707/59023103-b911e200-8857-11e9-94d3-433990022c0b.png">
