### PR TITLE
#166185765 reset muscle cache after deleting a muscle

### DIFF
--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -81,6 +81,24 @@ class Muscle(models.Model):
         """
         return False
 
+    def delete(self, *args, **kwargs):
+        """reset all cached info"""
+        for language in Language.objects.all():
+            delete_template_fragment_cache("exercise-overview", language.id)
+            delete_template_fragment_cache(
+                "exercise-overview-mobile", language.id
+            )
+            delete_template_fragment_cache(
+                "muscle-overview", language.id
+            )
+            delete_template_fragment_cache(
+                "equipment-overview", language.id
+            )
+        muscle_exercises = Exercise.objects.filter(muscles=self).iterator()
+        for exercise in muscle_exercises:
+            cache.delete(cache_mapper.get_exercise_muscle_bg_key(exercise))
+        super(Muscle, self).delete(*args, **kwargs)
+
 
 @python_2_unicode_compatible
 class Equipment(models.Model):

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -39,9 +39,13 @@ class MuscleListView(ListView):
     """
 
     model = Muscle
-    queryset = (Muscle.objects.all().order_by("-is_front", "name"),)
     context_object_name = "muscle_list"
     template_name = "muscles/overview.html"
+
+    def get_queryset(self):
+        if self.template_name == 'muscles/overview.html':
+            return Muscle.objects.all().order_by('-is_front', 'name'),
+        return Muscle.objects.all().order_by('-is_front', 'name')
 
     def get_context_data(self, **kwargs):
         """


### PR DESCRIPTION
#### What does this PR do?

- It seems that after deleting a muscle, it keeps appearing in descriptions etc. This is probably due to the cache not being correctly reset.The cache should be reset after a muscle has been deleted

#### Description of Task to be completed?

- delete muscle cache from exercises
- delete muscle cache from exercise_equipments
- delete muscle cache from exercise.sets_sets
- delete muscle cache from exercise_equipment

#### How should this be manually tested?
- Clone this repo and set up the application locally according to the [README](https://github.com/andela/wger-space/blob/ft-display-active-inactive-users-166185759/README.rst) file.
- `cd` into `wger-space`, start the development server and navigate to the web app on `http://127.0.0.1:8000/`
- Create a superuser in the application using the command `python manage.py createsuperuser` . 
- Log in to the app as the superuser  and navigate to the muscles endpoint
- delete one muscle from the list of muscles.
- when you navigate to muscle-overview you will notice the muscle that you deleted has disappeared.

#### What are the relevant pivotal tracker stories?

[#166185765](https://www.pivotaltracker.com/story/show/166185765)
