### PR TITLE
#166185761 Get all info for an exercise

### DIFF
--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -422,6 +422,38 @@ class ExercisesTestCase(WorkoutManagerTestCase):
         result = json.loads(response.content.decode("utf8"))
         self.assertEqual(len(result["suggestions"]), 0)
 
+    def filter_exercise(self, fail=True):
+        """
+        Helper function to test getting all exercise info
+        """
+
+        # 1 hit, "Very cool exercise"
+        response = self.client.get(
+            reverse("exercise-info"), {"term": "cool"}
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode("utf8"))
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result["info"][0]["value"], "Very cool exercise"
+        )
+        self.assertEqual(result["info"][0]["data"]["id"], 2)
+        self.assertEqual(
+            result["info"][0]["data"]["category"], "Another category"
+        )
+        self.assertEqual(result["info"][0]["data"]["image"], None)
+        self.assertEqual(
+            result["info"][0]["data"]["image_thumbnail"], None
+        )
+
+        # 0 hits, "Pending exercise"
+        response = self.client.get(
+            reverse("exercise-info"), {"term": "Pending"}
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content.decode("utf8"))
+        self.assertEqual(len(result["info"]), 0)
+
     def test_search_exercise_anonymous(self):
         """
         Test deleting an exercise by an anonymous user
@@ -436,6 +468,21 @@ class ExercisesTestCase(WorkoutManagerTestCase):
 
         self.user_login("test")
         self.search_exercise()
+
+    def test_filter_exercise_anonymous(self):
+        """
+        Test deleting an exercise by an anonymous user
+        """
+
+        self.filter_exercise()
+
+    def test_filter_exercise_logged_in(self):
+        """
+        Test deleting an exercise by a logged in user
+        """
+
+        self.user_login("test")
+        self.filter_exercise()
 
 
 class DeleteExercisesTestCase(WorkoutManagerDeleteTestCase):

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -255,6 +255,9 @@ urlpatterns += [
         exercises_api_views.search,
         name="exercise-search",
     ),
+    url(r'^api/v2/exercise/info/$',
+        exercises_api_views.ExerciseInfo.as_view(),
+        name='exercise-info'),
     url(
         r"^api/v2/ingredient/search/$",
         nutrition_api_views.search,

--- a/wger/utils/helpers.py
+++ b/wger/utils/helpers.py
@@ -30,6 +30,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.shortcuts import get_object_or_404
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.utils.translation import ugettext as _
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,41 @@ def make_token(user):
     token = default_token_generator.make_token(user)
 
     return uid, token
+
+
+def get_exercise_as_json(exercise, image, thumbnail):
+    exercise_json = {
+        'value': exercise.name,
+        'data': {
+            'id': exercise.id,
+            'name': exercise.name,
+            'description': exercise.description,
+            'category': _(exercise.category.name),
+            'image': image,
+            'image_thumbnail': thumbnail,
+            'muscles': [
+                muscles.name for muscles in exercise
+                .muscles.all()],
+            'muscles_secondary': [
+                muscles.name for muscles in exercise
+                .muscles_secondary.all()],
+            'equipment': [
+                equipment.name for equipment in exercise
+                .equipment.all()],
+        }
+    }
+    return exercise_json
+
+
+def query_exercises(exercise_name, Exercise):
+    if exercise_name:
+        exercises = (
+            Exercise.objects.filter(name__icontains=exercise_name)
+            .filter(status=Exercise.STATUS_ACCEPTED)
+            .order_by("category__name", "name")
+            .distinct()
+        )
+    return exercises
 
 
 def check_token(uidb64, token):


### PR DESCRIPTION
**What does this PR do?**

creates a new read-only API endpoint that collects all the information of an exercise such as muscles, category, images

**Description of Task to be completed?**

- add a new endpoint for picking all the info for an exercise
- Add a new view for the endpoint to return the required info

**How should this be manually tested?**

- clone the project on your machine
- setup the project following the instructions in the readme file
- checkout to the branch `ft-api-show-all-info-for-exercises-166185761`
- ensure all the environments are properly setup
- run the server and visit the endpoint `http://127.0.0.1:8000/api/v2/exercise/info/?term=<exercise-name>`
- The endpoint should be able to return all info for the specified exercise name
**Alternatively**
- use the review app link `https://wger-space-pr-18.herokuapp.com/api/v2/exercise/info/?term=<exercise-name>`
- You should be able to view all the info of the specified exercise name

**What are the relevant pivotal tracker stories?**

[#166185761](https://www.pivotaltracker.com/story/show/166185761)

**screenshots**

<img width="1136" alt="endpoint" src="https://user-images.githubusercontent.com/40593659/59213764-42aa1280-8bbe-11e9-90bf-1b2ab6853af1.png">
