### PR TITLE
#166185776 Deactivate Gym Trainers

### DIFF
--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -38,7 +38,8 @@
         {{current_user.obj.pk}}
     </td>
     <td>
-        {{current_user.obj}}
+        
+        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
 
         {% if current_user.perms.gym_trainer %}
             <span class="label label-primary">{% trans "Trainer" %}</span>


### PR DESCRIPTION
#### What does this PR do?
It allows managers to deactivate gym trainers.

#### Description of Task to be completed?
Add click-ability to the usernames in the gym username to access user information to be able to deactivate the user.

#### How should this be manually tested?
One should head on over to ```https://wger-space-pr-19.herokuapp.com/en/user/login``` and login as a gym manager ```muwonge``` password ```ke5B7nLBxdVBw2D```.
click on the username 
<img width="267" alt="Screen Shot 2019-06-11 at 11 14 34" src="https://user-images.githubusercontent.com/43015966/59255150-35cb0480-8c3a-11e9-991f-57807e89c516.png">

click on ```nicks``` gym.

you will see a table for the gym trainers and managers. 
<img width="800" alt="Screen Shot 2019-06-11 at 11 17 24" src="https://user-images.githubusercontent.com/43015966/59255333-90fcf700-8c3a-11e9-8797-a1865982ec0f.png">

click on nicks-bro and you should see this 
<img width="1300" alt="Screen Shot 2019-06-11 at 11 18 51" src="https://user-images.githubusercontent.com/43015966/59255422-bdb10e80-8c3a-11e9-8c1a-9f63b702beab.png">

click on deactivate the user and if it's successful, you should get 
<img width="1261" alt="Screen Shot 2019-06-11 at 11 20 20" src="https://user-images.githubusercontent.com/43015966/59255556-f3ee8e00-8c3a-11e9-989c-52c4f6b168b1.png">

check back in the manager's table you will see that ```nicks-bro's``` trainer tag is gone.
<img width="811" alt="Screen Shot 2019-06-11 at 11 22 49" src="https://user-images.githubusercontent.com/43015966/59255793-46c84580-8c3b-11e9-88d2-3a46dc4786cb.png">

These steps may be taken again in re-activating a user
#### What are the relevant pivotal tracker stories?
[#166185776](https://www.pivotaltracker.com/story/show/166185776)
