### PR TITLE
#166185760 Cache nutrition values for plans

### DIFF
--- a/wger/nutrition/__init__.py
+++ b/wger/nutrition/__init__.py
@@ -19,3 +19,4 @@
 from wger import get_version
 
 VERSION = get_version()
+default_app_config = 'wger.nutrition.app.Nutritionconfig'

--- a/wger/nutrition/app.py
+++ b/wger/nutrition/app.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class Nutritionconfig(AppConfig):
+    name = 'wger.nutrition'
+
+    def ready(self):
+        import wger.nutrition.signals
+        return wger.nutrition.signals

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -116,55 +116,61 @@ class NutritionPlan(models.Model):
         """
         Sums the nutritional info of all items in the plan
         """
-        use_metric = self.user.userprofile.use_metric
-        unit = "kg" if use_metric else "lb"
-        result = {
-            "total": {
-                "energy": 0,
-                "protein": 0,
-                "carbohydrates": 0,
-                "carbohydrates_sugar": 0,
-                "fat": 0,
-                "fat_saturated": 0,
-                "fibres": 0,
-                "sodium": 0,
-            },
-            "percent": {"protein": 0, "carbohydrates": 0, "fat": 0},
-            "per_kg": {"protein": 0, "carbohydrates": 0, "fat": 0},
-        }
+        cached_plan = cache.get(cache_mapper.get_nutrition_data(self.pk))
+        if not cached_plan:
+            use_metric = self.user.userprofile.use_metric
+            unit = "kg" if use_metric else "lb"
+            result = {
+                "total": {
+                    "energy": 0,
+                    "protein": 0,
+                    "carbohydrates": 0,
+                    "carbohydrates_sugar": 0,
+                    "fat": 0,
+                    "fat_saturated": 0,
+                    "fibres": 0,
+                    "sodium": 0,
+                },
+                "percent": {"protein": 0, "carbohydrates": 0, "fat": 0},
+                "per_kg": {"protein": 0, "carbohydrates": 0, "fat": 0},
+            }
 
-        # Energy
-        for meal in self.meal_set.select_related():
-            values = meal.get_nutritional_values(use_metric=use_metric)
-            for key in result["total"].keys():
-                result["total"][key] += values[key]
+            # Energy
+            for meal in self.meal_set.select_related():
+                values = meal.get_nutritional_values(use_metric=use_metric)
+                for key in result["total"].keys():
+                    result["total"][key] += values[key]
 
-        energy = result["total"]["energy"]
+            energy = result["total"]["energy"]
 
-        # In percent
-        if energy:
-            for key in result["percent"].keys():
-                result["percent"][key] = (
-                    result["total"][key]
-                    * ENERGY_FACTOR[key][unit]
-                    / energy
-                    * 100
-                )
+            # In percent
+            if energy:
+                for key in result["percent"].keys():
+                    result["percent"][key] = (
+                        result["total"][key]
+                        * ENERGY_FACTOR[key][unit]
+                        / energy
+                        * 100
+                    )
 
-        # Per body weight
-        weight_entry = self.get_closest_weight_entry()
-        if weight_entry:
-            for key in result["per_kg"].keys():
-                result["per_kg"][key] = (
-                    result["total"][key] / weight_entry.weight
-                )
+            # Per body weight
+            weight_entry = self.get_closest_weight_entry()
+            if weight_entry:
+                for key in result["per_kg"].keys():
+                    result["per_kg"][key] = (
+                        result["total"][key] / weight_entry.weight
+                    )
 
-        # Only 2 decimal places, anything else doesn't make sense
-        for key in result.keys():
-            for i in result[key]:
-                result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
+            # Only 2 decimal places, anything else doesn't make sense
+            for key in result.keys():
+                for i in result[key]:
+                    result[key][i] = Decimal(
+                        result[key][i]).quantize(TWOPLACES)
 
-        return result
+            cache.set(cache_mapper.get_nutrition_data(self.pk), result)
+            return result
+
+        return cached_plan
 
     def get_closest_weight_entry(self):
         """

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,25 @@
+from django.core.cache import cache
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from wger.utils.cache import cache_mapper
+
+signals = [post_save, post_delete]
+
+
+@receiver(signals, sender=NutritionPlan)
+@receiver(signals, sender=Meal)
+@receiver(signals, sender=MealItem)
+def cache_deletion_on_change(sender, instance, **kwargs):
+    """
+    delete cache key when there is a change
+     in the nutrition plan, meals or mealitem
+    """
+    if sender == Meal:
+        nutrition_plan_id = instance.plan_id
+    elif sender == MealItem:
+        nutrition_plan_id = Meal.objects.get(id=instance.meal_id).plan_id
+    else:
+        nutrition_plan_id = instance.id
+
+    cache.delete(cache_mapper.get_nutrition_data(nutrition_plan_id))

--- a/wger/nutrition/tests/test_nutritional_cache.py
+++ b/wger/nutrition/tests/test_nutritional_cache.py
@@ -1,0 +1,82 @@
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from wger.utils.cache import cache_mapper
+from wger.core.models import Language
+from django.core.cache import cache
+from django.contrib.auth.models import User
+
+
+class NutritionPlanCacheTestCase(WorkoutManagerTestCase):
+
+    def create_nutrition_plan(self):
+        nutrition_plan = NutritionPlan()
+        nutrition_plan.user = User.objects.create_user(username='sebbss')
+        nutrition_plan.language = Language.objects.get(short_name='en')
+        nutrition_plan.save()
+
+        meal = Meal()
+        meal.plan = nutrition_plan
+        meal.order = 1
+        meal.save()
+
+        meal_item = MealItem()
+        meal_item.meal = meal
+        meal_item.amount = 1
+        meal_item.ingredient_id = 1
+        meal_item.order = 1
+        return [nutrition_plan, meal, meal_item]
+
+    def test_cache_creation(self):
+        nutrition_plan = self.create_nutrition_plan()[0]
+        nutrition_plan.get_nutritional_values()
+        self.assertTrue(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+
+    def test_change_in_meal(self):
+        nutrition_object = self.create_nutrition_plan()
+        nutrition_plan = nutrition_object[0]
+        nutrition_plan.get_nutritional_values()
+        meal = nutrition_object[1]
+        self.assertTrue(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+        meal.save()
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+        nutrition_plan.get_nutritional_values()
+        self.assertTrue(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+        meal.delete()
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+
+    def test_change_in_meal_item(self):
+        nutrition_object = self.create_nutrition_plan()
+        nutrition_plan = nutrition_object[0]
+        nutrition_plan.get_nutritional_values()
+        meal_item = nutrition_object[2]
+        self.assertTrue(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+        meal_item.save()
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+        nutrition_plan.get_nutritional_values()
+        self.assertTrue(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+        meal_item.delete()
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+
+    def test_change_in_nutrition_plan(self):
+        nutrition_plan = self.create_nutrition_plan()[0]
+        nutrition_plan.get_nutritional_values()
+        self.assertTrue(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+        nutrition_plan.save()
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+        nutrition_plan.get_nutritional_values()
+        self.assertTrue(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))
+        nutrition_plan.delete()
+        self.assertFalse(
+            cache.get(cache_mapper.get_nutrition_data(nutrition_plan)))

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -67,6 +67,7 @@ class CacheKeyMapper(object):
     INGREDIENT_CACHE_KEY = "ingredient-{0}"
     WORKOUT_CANONICAL_REPRESENTATION = "workout-canonical-representation-{0}"
     WORKOUT_LOG_LIST = "workout-log-hash-{0}"
+    NUTRITIONAL_DATA_REPRESENTATION = "nutritional_data_representation-{0}"
 
     def get_pk(self, param):
         """
@@ -114,6 +115,12 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         """
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutrition_data(self, param):
+        """
+        Return the nutritional data representation
+        """
+        return self.NUTRITIONAL_DATA_REPRESENTATION.format(self.get_pk(param))
 
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
**What does this PR do?**
cache nutrition values after running the GET endpoint for nutrition plans 

**Description of Task to be completed?**

- add function that creates the cache of nutrition values
- add signals to delete the cache when a change is made in Meal, MealItem or Nutrition classes
- write tests for the added functionality

**How should this be manually tested?**

- clone the project on your machine
- setup the project following the instructions in the readme file
- checkout to the branch `ft-cache-nutrition-values-for-plan`
- run the tests using `python manage.py test wger.nutrition.tests.test_nutritional_cache`

**What are the relevant pivotal tracker stories?**

[#166185760](https://www.pivotaltracker.com/story/show/166185760)

