### PR TITLE
 #166185773 Change the way a user adds a meal

### DIFF
--- a/wger/nutrition/api/serializers.py
+++ b/wger/nutrition/api/serializers.py
@@ -23,6 +23,7 @@ from wger.nutrition.models import (
     MealItem,
     Meal,
     Ingredient,
+    NutritionPlan,
 )
 
 
@@ -87,3 +88,36 @@ class IngredientSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Ingredient
+
+
+class MealMealItemSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = MealItem
+
+    def validate(self, data):
+        plan_id = self.initial_data.get('plan_id')
+        time = self.initial_data.get('time')
+        order = 1
+
+        plan = NutritionPlan.objects.get(id=plan_id)
+
+        meal = Meal(
+            order=order,
+            plan=plan,
+            time=time
+        )
+        meal.save()
+
+        data.update(
+            {
+                "meal": meal,
+                "order": order
+            }
+        )
+        return data
+
+    def create(self, validated_data):
+        meal_item = MealItem(**validated_data)
+        meal_item.save()
+        return validated_data

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -19,6 +19,9 @@ from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
 
 from wger.nutrition.api.serializers import (
     NutritionPlanSerializer,
@@ -27,6 +30,7 @@ from wger.nutrition.api.serializers import (
     MealItemSerializer,
     MealSerializer,
     IngredientSerializer,
+    MealMealItemSerializer
 )
 from wger.nutrition.forms import UnitChooserForm
 from wger.nutrition.models import (
@@ -275,3 +279,14 @@ class MealItemViewSet(WgerOwnerObjectModelViewSet):
         Return an overview of the nutritional plan's values
         """
         return Response(MealItem.objects.get(pk=pk).get_nutritional_values())
+
+
+class MealMealItemView(APIView):
+
+    serializer_class = MealMealItemSerializer
+
+    def post(self, request):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -134,7 +134,8 @@ class MealItemForm(forms.ModelForm):
         required=False,
     )
     ingredient = forms.ModelChoiceField(
-        queryset=Ingredient.objects.all(), widget=forms.HiddenInput
+        queryset=Ingredient.objects.all(),
+        widget=forms.HiddenInput
     )
 
     class Meta:

--- a/wger/nutrition/templates/meal_item/add.html
+++ b/wger/nutrition/templates/meal_item/add.html
@@ -4,7 +4,7 @@
 {% load wger_extras %}
 
 
-{% block title %}{% trans "Edit meal item" %}{% endblock %}
+{% block title %}{% trans "Add a meal" %}{% endblock %}
 
 
 {% block header %}
@@ -25,8 +25,17 @@ $(document).ready(function() {
       class="form-horizontal">
     {% csrf_token %}
     {% render_form_errors form %}
-    {{form.ingredient}}
-
+    <div class="form-group">
+        {% comment %} <label for="time-field">Time (approx) - Optional</label> {% endcomment %}
+        
+        <div class="col-md-3"><label for="time-field">Time (approx) - Optional</label></div>
+        <div class="col-md-9" >
+            <input type="time" id="time-field" name="time-field"
+            min="9:00" max="18:00" 
+            class="form-control">
+        </div>
+    </div>
+    <div style="display: None;">{{form.ingredient}}</div>
     <div class="form-group {% if field.errors %}has-error{% endif %}" id="form-id_ingredient_searchfield">
         <label for="id_ingredient_searchfield" class="col-md-3 control-label">
             {% trans "Ingredient name" %}

--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -22,9 +22,14 @@ from wger.core.tests.base_testcase import (
     WorkoutManagerTestCase,
     WorkoutManagerEditTestCase,
     WorkoutManagerAddTestCase,
+    get_reverse
 )
-from wger.nutrition.models import Meal
+from wger.nutrition.models import Meal, MealItem
 from wger.nutrition.models import NutritionPlan
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
 
 
 class MealRepresentationTestCase(WorkoutManagerTestCase):
@@ -48,18 +53,6 @@ class EditMealTestCase(WorkoutManagerEditTestCase):
     url = "nutrition:meal:edit"
     pk = 5
     data = {"time": datetime.time(8, 12)}
-
-
-class AddMealTestCase(WorkoutManagerAddTestCase):
-    """
-    Tests adding a Meal
-    """
-
-    object_class = Meal
-    url = reverse("nutrition:meal:add", kwargs={"plan_pk": 4})
-    data = {"time": datetime.time(9, 2)}
-    user_success = "test"
-    user_fail = "admin"
 
 
 class PlanOverviewTestCase(WorkoutManagerTestCase):

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -264,6 +264,7 @@ urlpatterns += [
         name="ingredient-search",
     ),
     url(r"^api/v2/", include(router.urls)),
+    url(r"api/v2/meal-mealitem", nutrition_api_views.MealMealItemView.as_view())
 ]
 
 #


### PR DESCRIPTION
#### What does this PR do?

- Shortens the process of adding a meal to a nutrition plan.

#### Description of Task to be completed?

- Enable a user to add a meal from a single form.

#### How should this be manually tested?

- Login to the application on [heroku](https://wger-space-pr-24.herokuapp.com/en/software/features)
- Click on the **Nutrition** menu and select **Nutrition Plan**. 
- On the Nutrition Plan page, create a Nutrition Plan and click the button to add a meal.
- Fill in the subsequent form and save. This will redirect back to the Nutrition Plan page which will now display the meal you created.

#### Any background context you want to provide?

- Previously, a User would be redirected back to the page for displaying an overview of the nutrition plan after a meal was created. To add a meal item to the meal, the user had to click another button to be redirected to that view.
- The process above required three button clicks and three views in order to add a meal to a meal plan. This process was streamlined to one button click and one form view, achieving the same effect.

#### What are the relevant pivotal tracker stories?
[#166185773](https://www.pivotaltracker.com/story/show/166185773)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/6644707/59860859-6886a280-9388-11e9-9e63-7da36aefaf3e.png)
