### PR TITLE
#166185763 Add support for Fitbit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,9 @@ django-sortedm2m
 django-bower
 invoke==1.2.0
 requests
+python-dateutil
+requests-oauthlib
+fitbit==0.3.1
 # REST API
 djangorestframework>=3.2,<3.3
 django-filter==1.1.0

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -90,6 +90,9 @@ INSTALLED_APPS = (
     #social django
     # Django social login
     'social_django',
+
+
+    
 )
 
 # added list of external libraries to be installed by bower
@@ -219,7 +222,6 @@ SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get('GOOGLE_SECRET')
 
 SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get('FACEBOOK_KEY')
 SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get('FACEBOOK_SECRET')
-
 
 #
 # Internationalization

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -23,6 +23,7 @@ from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.contrib.sitemaps.views import sitemap
+from django.contrib.auth.decorators import login_required
 
 from wger.nutrition.sitemap import NutritionSitemap
 from wger.exercises.sitemap import ExercisesSitemap
@@ -41,6 +42,7 @@ from wger.core.api import views as core_api_views
 from wger.exercises.api import views as exercises_api_views
 from wger.nutrition.api import views as nutrition_api_views
 from wger.weight.api import views as weight_api_views
+from wger.weight.views import FitbitComplete
 
 #
 # REST API
@@ -247,6 +249,11 @@ urlpatterns += [
     url(
         r"^amazon-manifest\.webapp$",
         WebappManifestView.as_view(template_name="amazon-manifest.webapp"),
+    ),
+    url(
+        r"^fitbit-complete/$", 
+        login_required(FitbitComplete.as_view()),
+        name='fitbit-complete'
     ),
     # API
     url(r"^api/", include(v1_api.urls)),

--- a/wger/weight/templates/overview.html
+++ b/wger/weight/templates/overview.html
@@ -110,6 +110,13 @@
                 {% trans "Import from spreadsheet" %}
             </a>
         </li>
+        <li>
+            {% comment %} <a href="{% url 'sync-fitbit-weight' %}" {% auto_link_css flavour %}> {% endcomment %}
+            <a href="{% url 'fitbit-complete' %}" {% auto_link_css flavour %}>
+                <span class="{% fa_class 'upload' %}"></span>
+                {% trans "Import from Fitbit" %}
+            </a>
+        </li>
     </ul>
 </div>
 <a href="{% url 'weight:add' %}" class="btn btn-success btn-sm wger-modal-dialog">


### PR DESCRIPTION
#### What does this PR do?

- enable a user to retrieve weight logs from their Fitbit account

#### Description of Task to be completed?

- redirect a user to the Fitbit for authorization
- add a view for syncing to Fitbit and returning a user's weight log
-display the weight logs imported from Fitbit, in Wger

#### How should this be manually tested?

- Create an account with [Fitbit](https://accounts.fitbit.com/signup?lcl=en_GB&targetUrl=https%3A%2F%2Fwww.fitbit.com%2Flogin%2Ftransferpage%3Fredirect%3Dhttps%253A%252F%252Fwww.fitbit.com)
- Add a weight to your weight log on Fitbit
- Go to the Wger deployment for this PR on [Heroku](https://wger-space-pr-25.herokuapp.com/en/weight/overview/geo)
- Create an account with Wger and login
- On the ment bar, select `Weight overview` from the `Weight` menu
- On the `weight overview` page, click the `options` button and select `Import from Fitbit`
- Follow the prompts that authorize Wger to access your Fitbit account
- You will then be redirected to the Weight overview page where you will be able to see your updated weight 
   log

#### What are the relevant pivotal tracker stories?

[#166185763](https://www.pivotaltracker.com/story/show/166185763)
