### PR TITLE
#166185766 Make translations of exercises and ingredients easier

### DIFF
--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -29,6 +29,11 @@ $(document).ready(function() {
         }
     });
 });
+$(function() {
+        $('#select_language').change(function() {
+            this.form.submit();
+        });
+    });
 </script>
 {% endblock %}
 
@@ -38,7 +43,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache cache_timeout exercise-overview language.id %}
+{% cache 1 exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}
@@ -112,6 +117,15 @@ $(document).ready(function() {
            id="exercise-search"
            class="ajax-form-element form-control"
            placeholder="{% trans 'exercise name' %}">
+        <br />
+        <h4>{% trans "Choose language" %}</h4>
+        <form action="{% url 'exercise:exercise:overview' %}" method="get">
+            <select name="lang" id="select_language" class="form-control">
+                {% for language in language_list %}
+                <option {% if language.short_name == shown_language %}selected {% endif %} value="{{ language.short_name }}">{% trans language.full_name %}</option>
+                {% endfor %}
+            </select> 
+        </form>
 {% endblock %}
 
 

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -254,6 +254,12 @@ class ExercisesTestCase(WorkoutManagerTestCase):
         # Exercise was not added
         self.assertEqual(count_before, count_after)
 
+    def test_exercise_languages(self):
+        response = self.client.get(
+            reverse("exercise:exercise:overview"), {
+                "lang": "de"})
+        self.assertEqual(response.status_code, 200)
+
     def test_add_exercise_temp_user(self):
         """
         Tests adding an exercise with a logged in demo user

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -23,6 +23,11 @@
                 }
             });
         });
+        $(function() {
+                $('#select_language').change(function() {
+                    this.form.submit();
+                });
+            });
     </script>
 {% endblock %}
 
@@ -69,6 +74,15 @@
                class="ajax-form-element form-control"
                placeholder="{% trans 'ingredient name' %}"
                style="width:100%;">
+    </form>
+    <br />
+    <h4>{% trans "choose language" %}</h4>
+    <form action="{% url 'nutrition:ingredient:list' %}" method="get">
+        <select name="language_form" id="select_language" class="form-control">
+          {% for language in all_languages %}
+          <option {% if language.short_name == shown_language %}selected {% endif %} value="{{ language.short_name }}">{% trans language.full_name %}</option>
+          {% endfor %}
+        </select> 
     </form>
 {% endblock %}
 

--- a/wger/nutrition/tests/test_ingredient_overview.py
+++ b/wger/nutrition/tests/test_ingredient_overview.py
@@ -116,6 +116,12 @@ class OverviewPlanTestCase(WorkoutManagerTestCase):
         if logged_in and demo:
             self.assertContains(response, "Only registered users can do this")
 
+    def test_ingredient_languages(self):
+        response = self.client.get(
+            reverse("nutrition:ingredient:list"), {
+                "language_form": "de"})
+        self.assertEqual(response.status_code, 200)
+
     def test_ingredient_index_editor(self):
         """
         Tests the ingredient overview page as a logged in user with editor


### PR DESCRIPTION
**What does this PR do?**

This makes translations of exercises and ingredients easier, the user should be able to select a preferred language for the list of exercises and ingredients displayed

**Description of the task to be completed?**

- Add a selection field for the user to select the preferred language
- Ensure the exercises and ingredients lists show the selected language by the user

**How should this be manually tested?**

- clone the repo and set up the project following the instructions in the readme
- ensure all the environment variables are set up
- checkout to the branch `ft-make-translations-of-exercises-easier-166185766`
- Run the server and visit the links `http://127.0.0.1:8000/en/exercise/overview/` and  `http://localhost:8000/en/nutrition/ingredient/overview/`
- You should be able to see a language selection field where you click to translate the different languages

**Any background contexts you want to provide?**

currently, its only Deutsch and English that are working for both ingredients and exercises. Nederlands works for only one exercise, Portuguese for two exercises and cestina one exercise

**What are the relevant pivotal tracker stories?**

[#166185766](https://www.pivotaltracker.com/story/show/166185766)

**Screenshots**

exercise translated to deutsch

<img width="1204" alt="exercise" src="https://user-images.githubusercontent.com/40593659/59746917-81a42c00-9280-11e9-921e-eb03216fb1d3.png">

ingredients translated to deutsh

<img width="1208" alt="ingredients" src="https://user-images.githubusercontent.com/40593659/59746963-9c76a080-9280-11e9-9d9c-53db6b06d7ba.png">
