### PR TITLE
 feat(hover muscles): show exercises on mouse hover

### DIFF
--- a/wger/exercises/static/js/exercises.js
+++ b/wger/exercises/static/js/exercises.js
@@ -51,6 +51,59 @@ function wgerHighlightMuscle(element) {
   $('#' + divId).show();
 }
 
+
+function no_highlight(e){
+  var $muscle;
+  $muscle = $('.muscle');
+  $muscle.removeClass('muscle-active'); 
+  $muscle.addClass('muscle-inactive');
+  $(e).removeClass('muscle-inactive');
+  $(e).addClass('muscle-active').css('background', 'none');
+};
+
+function operations(muscleId,url,hide,e){
+  $('.muscle-background').css('background-image',
+    'url(/static/images/muscles/main/muscle-'+ muscleId +'.svg),' + url);
+  no_highlight(e)
+  hide
+  $('#muscle-'+ muscleId).show();
+};
+
+$(document).ready(function(){
+  $('.muscle-background').mousemove(function(e){
+      var m = e.offsetX;
+      var n = e.offsetY;
+      var front_url = 'url(/static/images/muscles/muscular_system_front.svg)'
+      var hide = $('.exercise-list').hide();
+      var back_url = 'url(/static/images/muscles/muscular_system_back.svg)'
+      var a, b ,b1, c, d, e1, e2, f,f1, g, g1, h, h1, t;
+
+      a = ( m <= 103 && m >= 49) && (n >= 51 && n <= 72 )
+      b= ( m <= 111 && m >= 102) && (n >= 73 && n <= 94 ) 
+      b1 = ( m <=46 && m >= 35) && (n >= 72 && n <= 97 )
+      c = (m <= 101 && m >= 50) && (n >= 144 && n <= 186 )
+      d = ( m <= 85 && m >=64) && (n >= 89 && n <= 135 )
+      e1 = ( m <= 110 && m >= 104) && (n >= 50 && n <= 64 ) 
+      e2= ( m <=48 && m >= 36) && (n >= 50 && n <= 64 )
+      f = ( m <= 100 && m >= 92) && (n >= 77 && n <= 100 )
+      f1 = ( m <=60 && m >= 48) && (n >= 78 && n <= 107 )
+      g = ( m <= 98 && m >= 87) && (n >= 90 && n <= 129 )
+      g1 = ( m <=63 && m >= 52) && (n >= 108 && n <= 126 )
+      h = ( m <= 98 && m >= 79) && (n >= 204 && n <= 262 ) 
+      h1= ( m <=73 && m >= 52) && (n >= 204 && n <= 262 )
+      t = ( m <= 98 && m >=54) && (n >= 32 && n <= 49 )
+
+      if (a){operations(4,front_url,hide,e)}
+      else if(b || b1){operations(1, front_url, hide, e)}
+      else if(c){operations(10,front_url, hide, e)}
+      else if(d){operations(6, front_url, hide, e)}
+      else if(e1 || e2){operations(2, front_url,hide,e)}
+      else if(f || f1){operations(3, front_url, hide, e)}
+      else if(g || g1){operations(14, front_url, hide, e)}
+      else if(h || h1){operations(7, back_url, hide, e)}
+      else if(t){operations(9, back_url, hide, e)};});
+});
+
 /*
  D3js functions
  */


### PR DESCRIPTION
#### What does this PR `do`?
allows the user to get exercises for a particular body part by hovering over it.

#### Description of Task to be completed?
- map out areas in an image that represent different muscles.
- attaching exercises to the highlighted muscles

#### How should this be manually tested?
- clone this repo
- run server and open http://127.0.0.1:7000/en/exercise/muscle/overview/
- hover over image parts to check out the functionality
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/43015966/59846693-331e8c80-9369-11e9-9532-cc2585e5b628.gif)

#### Any background context you want to provide?
in this feature due to complexity issues, only some of the body parts have been allocated this functionality to demonstrate how it should work for all muscles. 
- only two muscles in the back are working
- neck's and lower legs' muscles automatically flip the image to the back

#### What are the relevant pivotal tracker stories?
[#166185779](https://www.pivotaltracker.com/story/show/166185779)